### PR TITLE
ASR-4997: chisel with ubuntu pro

### DIFF
--- a/cmd/chisel/cmd_cut.go
+++ b/cmd/chisel/cmd_cut.go
@@ -92,6 +92,7 @@ func (cmd *cmdCut) Execute(args []string) error {
 			Components: archiveInfo.Components,
 			CacheDir:   cache.DefaultDir("chisel"),
 			PubKeys:    archiveInfo.PubKeys,
+			Pro:        archiveInfo.Pro,
 		})
 		if err != nil {
 			return err

--- a/internal/pgputil/openpgp.go
+++ b/internal/pgputil/openpgp.go
@@ -30,7 +30,9 @@ func DecodeKeys(armoredData []byte) (pubKeys []*packet.PublicKey, privKeys []*pa
 			privKeys = append(privKeys, privKey)
 		}
 		if pubKey, ok := p.(*packet.PublicKey); ok {
-			pubKeys = append(pubKeys, pubKey)
+			if !pubKey.IsSubkey {
+				pubKeys = append(pubKeys, pubKey)
+			}
 		}
 	}
 	return pubKeys, privKeys, nil

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -33,6 +33,7 @@ type Archive struct {
 	Suites     []string
 	Components []string
 	PubKeys    []*packet.PublicKey
+	Pro        string
 }
 
 // Package holds a collection of slices that represent parts of themselves.
@@ -337,6 +338,7 @@ type yamlArchive struct {
 	Components []string `yaml:"components"`
 	Default    bool     `yaml:"default"`
 	PubKeys    []string `yaml:"public-keys"`
+	Pro	       string   `yaml:"pro"`
 	// V1PubKeys is used for compatibility with format "chisel-v1".
 	V1PubKeys []string `yaml:"v1-public-keys"`
 }
@@ -495,6 +497,7 @@ func parseRelease(baseDir, filePath string, data []byte) (*Release, error) {
 			Version:    details.Version,
 			Suites:     details.Suites,
 			Components: details.Components,
+			Pro:        details.Pro,
 			PubKeys:    archiveKeys,
 		}
 	}


### PR DESCRIPTION
### BEFORE

- only supported a single repo, the regular ubuntu one

### AFTER

- supports multiple repos, uses the newest package version it finds
- ubuntu pro fips-updates is supported (esm-apps, esm-infra not there yet)