### PR TITLE
ASR-5037: adding InRelease labels for esm-infra and esm-apps

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -276,7 +276,7 @@ func (index *ubuntuIndex) fetchRelease() error {
 	if err != nil {
 		return fmt.Errorf("cannot parse InRelease file: %v", err)
 	}
-	supportedLabels := []string{"Ubuntu", "UbuntuProFIPS", "UbuntuFIPSUpdates"}
+	supportedLabels := []string{"Ubuntu", "UbuntuProFIPS", "UbuntuFIPSUpdates", "UbuntuESM", "UbuntuESMApps"}
 	var section control.Section
 	for _, label := range supportedLabels {
 		section = ctrl.Section(label)


### PR DESCRIPTION
### BEFORE

- only supported pro repo was fips-updates

### AFTER

- fips-updates, esm-apps, esm-infra are supported


the relevant InRelease files

- https://esm.ubuntu.com/apps/ubuntu/dists/jammy-apps-security/InRelease
- https://esm.ubuntu.com/apps/ubuntu/dists/jammy-apps-updates/InRelease
- https://esm.ubuntu.com/infra/ubuntu/dists/jammy-infra-security/InRelease
- https://esm.ubuntu.com/infra/ubuntu/dists/jammy-infra-updates/InRelease

![Screenshot from 2024-03-20 10-14-29](https://github.com/Delta-Risk-LLC/chisel/assets/42749440/b0adcb9f-a84d-4a6e-a999-c7374839041e)

![image](https://github.com/Delta-Risk-LLC/chisel/assets/42749440/1968b413-e3dc-4dec-a3de-ad0d00214654)

