### PR TITLE
AE-8502-1: Add support for hard links

### DIFF
--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -250,35 +250,24 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 
 			// Create the entry itself.
 			if tarHeader.Typeflag == tar.TypeLink {
-				logf("Handling hardlink for: %s", targetPath)
-
 				// Handle hard links
 				originalPath := tarHeader.Linkname
-				logf("Link name for hard link: %s", originalPath)
 
 				// Remove the leading "." if it exists
 				if strings.HasPrefix(originalPath, "./") {
 					originalPath = originalPath[1:]
-					logf("Adjusted original path to: %s", originalPath)
 				}				
 
 				// check if the original file to link to exists
 				createdFilePath, exists := createdFiles[originalPath]
-				logf("Created file path for original: %s, exists: %v", createdFilePath, exists)
 
 				if exists {
 					// If the original file exists, create a hard link to it
-					logf("%s and %s", options.TargetDir, targetPath)
 					err := os.Link(createdFilePath, filepath.Join(options.TargetDir, targetPath))
-					logf("Creating hard link from %s to %s", createdFilePath, filepath.Join(options.TargetDir, targetPath))
-
 					if err != nil {
 						return fmt.Errorf("failed to create hard link from %s to %s: %w", createdFilePath, targetPath, err)
 					}
-					logf("Successfully created hard link to: %s", filepath.Join(options.TargetDir, targetPath))
-
 				} else {
-					logf("Original file does not exist, will create a new file at: %s", filepath.Join(options.TargetDir, targetPath))
 					// If the original file does not exist, create the file normally
 					createOptions := &fsutil.CreateOptions{
 						Path:        filepath.Join(options.TargetDir, targetPath),
@@ -295,8 +284,6 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				}
 
 			} else {
-				logf("Regular file or symlink for: %s", targetPath)
-
 				// Regular file or symlink handling
 				createOptions := &fsutil.CreateOptions{
 					Path:        filepath.Join(options.TargetDir, targetPath),
@@ -312,10 +299,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 
 				// Track the created file for potential hard links
 				createdFiles[targetPath] = filepath.Join(options.TargetDir, targetPath)
-				logf("Tracked created file for potential hard link: %s", createdFiles[targetPath])
 			}
-
-			logf("Current state of created files: %v", createdFiles)
 		}
 	}
 

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -127,6 +127,8 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 	}()
 
 	pendingPaths := make(map[string]bool)
+	createdFiles := make(map[string]string) // Track created file paths for hard links
+	
 	for extractPath, extractInfos := range options.Extract {
 		for _, extractInfo := range extractInfos {
 			if !extractInfo.Optional {

--- a/internal/deb/extract.go
+++ b/internal/deb/extract.go
@@ -128,7 +128,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 
 	pendingPaths := make(map[string]bool)
 	createdFiles := make(map[string]string) // Track created file paths for hard links
-	
+
 	for extractPath, extractInfos := range options.Extract {
 		for _, extractInfo := range extractInfos {
 			if !extractInfo.Optional {
@@ -260,7 +260,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 				if strings.HasPrefix(originalPath, "./") {
 					originalPath = originalPath[1:]
 					logf("Adjusted original path to: %s", originalPath)
-                }				
+				}				
 
 				// check if the original file to link to exists
 				createdFilePath, exists := createdFiles[originalPath]
@@ -268,7 +268,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 
 				if exists {
 					// If the original file exists, create a hard link to it
-					logf("%s and %s",options.TargetDir, targetPath)
+					logf("%s and %s", options.TargetDir, targetPath)
 					err := os.Link(createdFilePath, filepath.Join(options.TargetDir, targetPath))
 					logf("Creating hard link from %s to %s", createdFilePath, filepath.Join(options.TargetDir, targetPath))
 
@@ -276,7 +276,7 @@ func extractData(dataReader io.Reader, options *ExtractOptions) error {
 						return fmt.Errorf("failed to create hard link from %s to %s: %w", createdFilePath, targetPath, err)
 					}
 					logf("Successfully created hard link to: %s", filepath.Join(options.TargetDir, targetPath))
-					
+
 				} else {
 					logf("Original file does not exist, will create a new file at: %s", filepath.Join(options.TargetDir, targetPath))
 					// If the original file does not exist, create the file normally


### PR DESCRIPTION
Currently, the chisel code does not support binaries with hard links. It only supports regular files or symlinks. This was noticed while working on chiseling the report-pdf-creator fargate. 

When we created a new bzip2 slice:

```
package: bzip2

# libs: https://packages.ubuntu.com/noble/bzip2
# contents: https://packages.ubuntu.com/noble/amd64/bzip2/filelist
slices:
  bins:
    essential:
      - libc6_libs
      - libbz2-1.0_libs
    contents:
      /bin/bzip2:
      /bin/bunzip2:
```

We noticed that the /bin/bzip2 binary was empty with 0 bytes:
```
I have no name!@0c003287e257:/bin# ls -ltr
total 4148
-rwxr-xr-x 1 0 0       0 Oct  7 16:16 bzip2
-rwxr-xr-x 1 0 0   39296 Oct  7 16:16 bunzip2
```


After inspecting the deb package we can see that the bzcat and bzip2 binaries are hard links to ./bin/bunzip2 

```
(backend) ➜  backend git:(AE-8502) ✗ dpkg-deb -c bzip2_1.0.8-5build1_amd64.deb
drwxr-xr-x root/root         0 2022-03-23 05:45 ./
drwxr-xr-x root/root         0 2022-03-23 05:45 ./bin/
-rwxr-xr-x root/root     39296 2022-03-23 05:45 ./bin/bunzip2
hrwxr-xr-x root/root         0 2022-03-23 05:45 ./bin/bzcat link to ./bin/bunzip2
hrwxr-xr-x root/root         0 2022-03-23 05:45 ./bin/bzip2 link to ./bin/bunzip2
```


After adding the hard link support to the chisel code and building our chiseled container again, the bzcat and bzip2 binaries are now being linked correctly. 

```
(backend) ➜  backend git:(AE-8502) ✗ docker run --rm -it backend:report-pdf-creator_JCR863_v154
I have no name!@ab94a38c4c97:/# cd bin
I have no name!@ab94a38c4c97:/bin# ls -ltr
total 4216
-rwxr-xr-x 3 0 0   39296 Oct 10 14:53 bzip2
-rwxr-xr-x 3 0 0   39296 Oct 10 14:53 bzcat
-rwxr-xr-x 3 0 0   39296 Oct 10 14:53 bunzip2
```

here are some logs to  understand what is happening in the code:
```
2024/10/10 19:10:42 Extracting package: bzip2
2024/10/10 19:10:42 About to extract package: bzip2
2024/10/10 19:10:42 Extracting files from package "bzip2"...
2024/10/10 19:10:42 Reading entry: ./, type: 53, size: 0
2024/10/10 19:10:42 Reading entry: ./bin/, type: 53, size: 0
2024/10/10 19:10:42 Reading entry: ./bin/bunzip2, type: 48, size: 39296
2024/10/10 19:10:42 Creating entry for path: /slices/bin, extractInfos length: 0
2024/10/10 19:10:42 Regular file or symlink for: /bin/bunzip2
2024/10/10 19:10:42 Creating entry for path: /slices/bin/bunzip2, extractInfos length: 1
2024/10/10 19:10:42 Tracked created file for potential hard link: /slices/bin/bunzip2
2024/10/10 19:10:42 Current state of created files: map[/bin/bunzip2:/slices/bin/bunzip2]
2024/10/10 19:10:42 Reading entry: ./bin/bzcat, type: 49, size: 0
2024/10/10 19:10:42 Handling hardlink for: /bin/bzcat
2024/10/10 19:10:42 Link name for hard link: ./bin/bunzip2
2024/10/10 19:10:42 Adjusted original path to: /bin/bunzip2
2024/10/10 19:10:42 Created file path for original: /slices/bin/bunzip2, exists: true
2024/10/10 19:10:42 Original file exists at: /slices/bin/bunzip2
2024/10/10 19:10:42 Creating hard link for /slices/bin/bzcat to /slices/bin/bunzip2
2024/10/10 19:10:42 Successfully created hard link for: /slices/bin/bzcat
2024/10/10 19:10:42 Current state of created files: map[/bin/bunzip2:/slices/bin/bunzip2]
2024/10/10 19:10:42 Reading entry: ./bin/bzdiff, type: 48, size: 2225
2024/10/10 19:10:42 Reading entry: ./bin/bzexe, type: 48, size: 4893
2024/10/10 19:10:42 Reading entry: ./bin/bzgrep, type: 48, size: 3775
2024/10/10 19:10:42 Reading entry: ./bin/bzip2, type: 49, size: 0
2024/10/10 19:10:42 Handling hardlink for: /bin/bzip2
2024/10/10 19:10:42 Link name for hard link: ./bin/bunzip2
2024/10/10 19:10:42 Adjusted original path to: /bin/bunzip2
2024/10/10 19:10:42 Created file path for original: /slices/bin/bunzip2, exists: true
2024/10/10 19:10:42 Original file exists at: /slices/bin/bunzip2
2024/10/10 19:10:42 Creating hard link for /slices/bin/bzip2 to /slices/bin/bunzip2 
2024/10/10 19:10:42 Successfully created hard link for: /slices/bin/bzip2
2024/10/10 19:10:42 Current state of created files: map[/bin/bunzip2:/slices/bin/bunzip2]
.
.
.
2024/10/10 19:10:42 Successfully extracted package: bzip2
2024/10/10 19:10:42 /bin/bzip2 binary size: 39296 bytes
2024/10/10 19:10:42 bzip2 binary permissions: -rwxr-xr-x
2024/10/10 19:10:42 /bin/bunzip2 binary size: 39296 bytes
2024/10/10 19:10:42 bzip2 binary permissions: -rwxr-xr-x
```

Previously these commands produced no output, now they do:

```
I have no name!@a61f03d0da85:/# bin/bzcat -version
bzcat: Bad flag `-version'
bzip2, a block-sorting file compressor.  Version 1.0.8, 13-Jul-2019.

   usage: bzcat [flags and input files in any order]

   -h --help           print this message
   -d --decompress     force decompression
   -z --compress       force compression
   -k --keep           keep (don't delete) input files
   -f --force          overwrite existing output files
   -t --test           test compressed file integrity
   -c --stdout         output to standard out
   -q --quiet          suppress noncritical error messages
   -v --verbose        be verbose (a 2nd -v gives more)
   -L --license        display software version & license
   -V --version        display software version & license
   -s --small          use less memory (at most 2500k)
   -1 .. -9            set block size to 100k .. 900k
   --fast              alias for -1
   --best              alias for -9

   If invoked as `bzip2', default action is to compress.
              as `bunzip2',  default action is to decompress.
              as `bzcat', default action is to decompress to stdout.

   If no file names are given, bzip2 compresses or decompresses
   from standard input to standard output.  You can combine
   short flags, so `-v -4' means the same as -v4 or -4v, &c.
```

```
I have no name!@a61f03d0da85:/# bin/bzip2 -version
bzip2: Bad flag `-version'
bzip2, a block-sorting file compressor.  Version 1.0.8, 13-Jul-2019.

   usage: bzip2 [flags and input files in any order]

   -h --help           print this message
   -d --decompress     force decompression
   -z --compress       force compression
   -k --keep           keep (don't delete) input files
   -f --force          overwrite existing output files
   -t --test           test compressed file integrity
   -c --stdout         output to standard out
   -q --quiet          suppress noncritical error messages
   -v --verbose        be verbose (a 2nd -v gives more)
   -L --license        display software version & license
   -V --version        display software version & license
   -s --small          use less memory (at most 2500k)
   -1 .. -9            set block size to 100k .. 900k
   --fast              alias for -1
   --best              alias for -9

   If invoked as `bzip2', default action is to compress.
              as `bunzip2',  default action is to decompress.
              as `bzcat', default action is to decompress to stdout.

   If no file names are given, bzip2 compresses or decompresses
   from standard input to standard output.  You can combine
   short flags, so `-v -4' means the same as -v4 or -4v, &c.
```

The fact that the chiseled report-pdf-creator builds and functions correctly proves that the bzip2 binary is installed correctly and works.
Link to PR: [Link to PR](https://github.com/msi-activeeye/backend/pull/5646)](https://github.com/msi-activeeye/backend/pull/5646)
